### PR TITLE
Change to be able to overload communes list

### DIFF
--- a/lib/cog.js
+++ b/lib/cog.js
@@ -1,8 +1,19 @@
 /* eslint unicorn/numeric-separators-style: off */
+const fs = require('fs')
 const {groupBy} = require('lodash')
 
-const communesActuelles = require('@etalab/decoupage-administratif/data/communes.json')
+const communesFixPath = process.env.COMMUNES_FIX_PATH_JSON ? process.env.COMMUNES_FIX_PATH_JSON : undefined
+
+let communesFix = []
+if (fs.existsSync(communesFixPath)) {
+    communesFix = require(communesFixPath)
+}
+
+
+let communesActuelles = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))
+
+communesActuelles = [...communesActuelles, ...communesFix]
 
 const communesAnciennes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-deleguee', 'commune-associee'].includes(c.type))


### PR DESCRIPTION
Chaneg to manage the following error

```
Unhandled Rejection at: Promise {
  <rejected> Error: Code commune inconnue : 27676
      at getNomCommune (/home/majic/mnt/2021/adresses-cadastre/lib/cog.js:67:11)
      at computeAdresse (/home/majic/mnt/2021/adresses-cadastre/lib/adresse.js:40:17)
      at /home/majic/mnt/2021/adresses-cadastre/lib/commune.js:19:25
      at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3585:27
      at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4967:15
      at baseForOwn (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3032:24)
      at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4936:18
      at baseMap (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3584:7)
      at Function.map (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:9622:14)
      at interceptor (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:17094:35)
      at thru (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:8859:14)
      at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4430:28
      at arrayReduce (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:697:21)
      at baseWrapperValue (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4429:14)
      at LazyWrapper.lazyValue [as value] (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:1901:16)
      at baseWrapperValue (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4427:25)
} reason: Error: Code commune inconnue : 27676
    at getNomCommune (/home/majic/mnt/2021/adresses-cadastre/lib/cog.js:67:11)
    at computeAdresse (/home/majic/mnt/2021/adresses-cadastre/lib/adresse.js:40:17)
    at /home/majic/mnt/2021/adresses-cadastre/lib/commune.js:19:25
    at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3585:27
    at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4967:15
    at baseForOwn (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3032:24)
    at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4936:18
    at baseMap (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:3584:7)
    at Function.map (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:9622:14)
    at interceptor (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:17094:35)
    at thru (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:8859:14)
    at /home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4430:28
    at arrayReduce (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:697:21)
    at baseWrapperValue (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4429:14)
    at LazyWrapper.lazyValue [as value] (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:1901:16)
    at baseWrapperValue (/home/majic/mnt/2021/adresses-cadastre/node_modules/lodash/lodash.js:4427:25)
```

You need to set environment variable e.g `export COMMUNES_FIX_PATH_JSON=$(pwd)/communes-fix.json` with file `communes-fix.json` (content visible below). Athough the city dissapears in the official cities list, in the locaux, a reference to this particular city code is used. Without the addition, the info to get the name from the code made the code fails as seen in below thrown error.

```
[{
    "code": "27676",
    "nom": "Les Trois Lacs",
    "typeLiaison": 0,
    "arrondissement": "271",
    "departement": "27",
    "region": "28",
    "type": "commune-actuelle",
    "rangChefLieu": 0,
    "codesPostaux": [ "27940" ],
    "population": 2712
}]
```